### PR TITLE
add no-optional as an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,15 +11,13 @@ function merge (a, b) {
 }
 
 function mergeDeps (p, opts) {
-  var m = !opts || opts.dev !== false
-        ? merge(
-            merge(
-              merge({}, p.dependencies), 
-              p.devDependencies
-            ),
-            p.optionalDependencies
-          )
-        : merge(p.dependencies, p.optionalDependencies)
+  var m = merge({}, p.dependencies);
+  if (opts && opts.dev) {
+    m = merge(m, p.devDependencies);
+  }
+  if (!opts || !opts.no-optional) {
+    m = merge(m, p.optionalDependencies);
+  }
   var a = []
   for(var k in m) a.push(k + '@' + m[k])
   return a

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function mergeDeps (p, opts) {
   if (opts && opts.dev) {
     m = merge(m, p.devDependencies);
   }
-  if (!opts || !opts.noOptional) {
+  if (!opts || !opts['no-optional']) {
     m = merge(m, p.optionalDependencies);
   }
   var a = []

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function mergeDeps (p, opts) {
   if (opts && opts.dev) {
     m = merge(m, p.devDependencies);
   }
-  if (!opts || !opts.no-optional) {
+  if (!opts || !opts.noOptional) {
     m = merge(m, p.optionalDependencies);
   }
   var a = []


### PR DESCRIPTION
I am using npmd as npm's alternative to install node packages offline. However, one annoying thing is a lot of package has optional native dependencies and while we run npmd install, the node-gyp will try to download node's source and timeout because of restricted internet connection. Since npm has `--no-optional` option to skip install optionalDependency, it would be nice to have it support in npmd as well, and it will super helpful to solve our specific problem.
